### PR TITLE
complete t9-delete-comment. Created new 'comments' controller, moving old related code into it

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -339,6 +339,37 @@ describe("/api/articles/:article_id/comments", () => {
     });
 });
 
+describe("/api/comments/:comment_id", () => {
+    test("DELETE204: successfully deletes comment by id, returning no content", () => {
+        return request(app)
+            .delete("/api/comments/5")
+            .expect(204)
+            .then(({ body }) => {
+                expect(body).toEqual({});
+                return db.query(`SELECT * FROM comments WHERE comment_id = 5`);
+            })
+            .then(({ rows }) => {
+                expect(rows).toHaveLength(0);
+            });
+    });
+    test("DELETE400: responds with appropriate error message when comment_id is not a valid id", () => {
+        return request(app)
+            .delete("/api/comments/not-valid-id")
+            .expect(400)
+            .then(({ body }) => {
+                expect(body.msg).toBe("invalid id");
+            });
+    });
+    test("DELETE404: responds with appropriate error message when comment_id is valid but doesn't exist", () => {
+        return request(app)
+            .delete("/api/comments/98327")
+            .expect(404)
+            .then(({ body }) => {
+                expect(body.msg).toBe("comment does not exist");
+            });
+    });
+});
+
 describe("Generic error handling", () => {
     test("GET404: should respond with a 404 error if endpoint doesn't exist", () => {
         return request(app).get("/api/no-endpoint").expect(404);

--- a/app.js
+++ b/app.js
@@ -5,10 +5,13 @@ const { getTopics } = require("./controllers/topics-controller");
 const {
     getArticles,
     getArticleById,
-    getCommentsByArticleId,
-    postCommentByArticleId,
     patchArticleById,
 } = require("./controllers/articles-controller");
+const {
+    getCommentsByArticleId,
+    postCommentByArticleId,
+    removeCommentById,
+} = require("./controllers/comments-controller");
 const {
     psqlErrorHandlers,
     customErrorHandler,
@@ -28,6 +31,8 @@ app.patch("/api/articles/:article_id", patchArticleById);
 
 app.get("/api/articles/:article_id/comments", getCommentsByArticleId);
 app.post("/api/articles/:article_id/comments", postCommentByArticleId);
+
+app.delete("/api/comments/:comment_id", removeCommentById);
 
 app.use(psqlErrorHandlers);
 app.use(customErrorHandler);

--- a/controllers/articles-controller.js
+++ b/controllers/articles-controller.js
@@ -1,8 +1,6 @@
 const {
     selectArticles,
     selectArticleById,
-    selectCommentsByArticleId,
-    insertCommentByArticleId,
     updateArticleById,
 } = require("../models/articles-model.js");
 
@@ -36,47 +34,4 @@ exports.patchArticleById = (req, res, next) => {
             res.status(200).send({ article });
         })
         .catch(next);
-};
-
-exports.getCommentsByArticleId = (req, res, next) => {
-    const { article_id } = req.params;
-    selectArticleById(article_id)
-        .then(() => {
-            return selectCommentsByArticleId(article_id);
-        })
-        .then((comments) => {
-            res.status(200).send({ comments });
-        })
-        .catch(next);
-};
-
-exports.postCommentByArticleId = (req, res, next) => {
-    const { article_id } = req.params;
-    const { username, body } = req.body;
-
-    // Check comment is valid
-    if (
-        username === undefined ||
-        body === undefined ||
-        Object.keys(req.body).length > 2
-    ) {
-        next({
-            status: 400,
-            msg: "request body is not a valid comment object",
-        });
-    }
-
-    // Check article exists
-    selectArticleById(article_id)
-        .then(() => {
-            // Post comment
-            const commentToPost = [article_id, username, body];
-            return insertCommentByArticleId(commentToPost);
-        })
-        .then((comment) => {
-            res.status(201).send({ comment });
-        })
-        .catch((err) => {
-            next(err);
-        });
 };

--- a/controllers/comments-controller.js
+++ b/controllers/comments-controller.js
@@ -1,0 +1,58 @@
+const { selectArticleById } = require("../models/articles-model");
+const {
+    selectCommentsByArticleId,
+    insertCommentByArticleId,
+    deleteCommentById,
+} = require("../models/comments-model");
+
+exports.getCommentsByArticleId = (req, res, next) => {
+    const { article_id } = req.params;
+    selectArticleById(article_id)
+        .then(() => {
+            return selectCommentsByArticleId(article_id);
+        })
+        .then((comments) => {
+            res.status(200).send({ comments });
+        })
+        .catch(next);
+};
+
+exports.postCommentByArticleId = (req, res, next) => {
+    const { article_id } = req.params;
+    const { username, body } = req.body;
+
+    // Check comment is valid
+    if (
+        username === undefined ||
+        body === undefined ||
+        Object.keys(req.body).length > 2
+    ) {
+        next({
+            status: 400,
+            msg: "request body is not a valid comment object",
+        });
+    }
+
+    // Check article exists
+    selectArticleById(article_id)
+        .then(() => {
+            // Post comment
+            const commentToPost = [article_id, username, body];
+            return insertCommentByArticleId(commentToPost);
+        })
+        .then((comment) => {
+            res.status(201).send({ comment });
+        })
+        .catch((err) => {
+            next(err);
+        });
+};
+
+exports.removeCommentById = (req, res, next) => {
+    const { comment_id } = req.params;
+    deleteCommentById(comment_id)
+        .then(() => {
+            res.status(204).send();
+        })
+        .catch(next);
+};

--- a/endpoints.json
+++ b/endpoints.json
@@ -95,5 +95,10 @@
                 "article_id": 7
             }
         }
+    },
+    "DELETE /api/comments/:comment_id": {
+        "description": "deletes a comment by comment_id. No response is returned.",
+        "queries": [],
+        "exampleResponse": {}
     }
 }

--- a/models/articles-model.js
+++ b/models/articles-model.js
@@ -51,34 +51,3 @@ exports.updateArticleById = (article_id, inc_votes) => {
             return rows[0];
         });
 };
-
-exports.selectCommentsByArticleId = (article_id) => {
-    return db
-        .query(
-            `SELECT comments.*
-             FROM comments
-             LEFT JOIN articles
-             ON comments.article_id = articles.article_id
-             WHERE comments.article_id = $1
-             ORDER BY created_at DESC`,
-            [article_id]
-        )
-        .then(({ rows }) => {
-            return rows;
-        });
-};
-
-exports.insertCommentByArticleId = (commentToPost) => {
-    return db
-        .query(
-            `INSERT INTO comments
-            (article_id, author, body)
-        VALUES
-            ($1, $2, $3)
-        RETURNING *`,
-            commentToPost
-        )
-        .then(({ rows }) => {
-            return rows[0];
-        });
-};

--- a/models/comments-model.js
+++ b/models/comments-model.js
@@ -1,0 +1,50 @@
+const db = require("../db/connection");
+
+exports.selectCommentsByArticleId = (article_id) => {
+    return db
+        .query(
+            `SELECT comments.*
+             FROM comments
+             LEFT JOIN articles
+             ON comments.article_id = articles.article_id
+             WHERE comments.article_id = $1
+             ORDER BY created_at DESC`,
+            [article_id]
+        )
+        .then(({ rows }) => {
+            return rows;
+        });
+};
+
+exports.insertCommentByArticleId = (commentToPost) => {
+    return db
+        .query(
+            `INSERT INTO comments
+            (article_id, author, body)
+        VALUES
+            ($1, $2, $3)
+        RETURNING *`,
+            commentToPost
+        )
+        .then(({ rows }) => {
+            return rows[0];
+        });
+};
+
+exports.deleteCommentById = (comment_id) => {
+    return db
+        .query(
+            `DELETE FROM comments
+        WHERE comment_id = $1
+        RETURNING *`,
+            [comment_id]
+        )
+        .then(({ rows }) => {
+            if (rows.length === 0) {
+                return Promise.reject({
+                    status: 404,
+                    msg: "comment does not exist",
+                });
+            }
+        });
+};


### PR DESCRIPTION
Where I've moved some old code into a new `comments-controller.js` file, I have had to `require` in `selectArticleById`.

This is because I used this model method to check whether articles existed for checking valid article id's. I don't know if requiring in an 'article' model method into the 'comments' controller is bad organisation, or perfectly fine.

The alternative would be to create utils functions which handle this, however, I believe I've been advised against this as it's just code bloat, when the already-existing `selectArticleById` is sufficient. (It's entirely possible I misunderstood the advice regarding that).